### PR TITLE
Add review issue template

### DIFF
--- a/.live-demo-content/issue-templates/performing-code-review.md
+++ b/.live-demo-content/issue-templates/performing-code-review.md
@@ -1,0 +1,3 @@
+Currently, the notebook `analyses/explore_spotify_variation.Rmd` begins to explore variation in the spotify songs dataset using only a PCA.
+We'd like to expand this analysis to also visualize a UMAP from this data, as well as identify and visualize variables in the dataset which may contribute to the variation seen in the UMAP.
+One particular item to be aware of is that the notebook is currently deterministic with only PCA, but when adding UMAP we will be adding some stochasticity; therefore, a random seed will need to be set to ensure reproducibility.


### PR DESCRIPTION
Towards #5 

This PR adds the issue template for live demonstration on performing code review, associated with the spotify PCA->UMAP. 
I also decided to leave some low-hanging fruit for review here - the issue specifically requests to set the seed, but the author of the PR will forget to do so, so the reviewer will have to request. This can demonstrate that going back to the issue while reviewing code is important, and that if the author carefully notes what is in the issue, things may go a tad more smoothly for everyone.