### PR TITLE
Create Markdown file with live demo PR text

### DIFF
--- a/.live-demo-content/spotify-pr-text.md
+++ b/.live-demo-content/spotify-pr-text.md
@@ -1,0 +1,6 @@
+Closes <issue number>
+
+In this PR, I'm adding UMAP visualization to the Spotify notebook. 
+I used the `umap` package to calculate UMAP coordinates from the PCs.
+
+I've included two plots where songs are colored by `instrumentalness` and `mode` variables and used the `patchwork` package to combine these panels.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ If you do not provide these inputs, you will have to manually assign the resulti
 
 * Whoever is assigned [the issue associated with demonstrating PR review](.live-demo-content/issue-templates/performing-code-review.md) will need to prepare a branch and file a PR, with several commits (whose messages have varying levels of information), that will be reviewed during the live demonstration.
 * This branch should ultimately modify contents of [this baseline notebook](analyses/explore-spotify-variation.Rmd) to match [this updated notebook](.live-demo-content/explore-spotify-variation-with-UMAPs.Rmd).
-* A PR should then be filed to `main`, using _TODO: this forthcoming file which contains the PR comment text._
+* A PR should then be filed to `main`, using the text in [`.live-demo-content/spotify-pr-text.md`](.live-demo-content/spotify-pr-text.md).
 


### PR DESCRIPTION
⚠️  Stacked on #25 

I've named my branch poorly since I believe this closes #12 😄 

I'm adding a Markdown file to `.live-demo-content` called `spotify-pr-text.md`. It's relatively sparse. I should perhaps include a description of the results in the text itself. What do you think? 

